### PR TITLE
Add OperationsController, Jasypt encryption, and standardize error responses

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,11 @@
 			<artifactId>flyway-core</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>com.github.ulisesbocchio</groupId>
+			<artifactId>jasypt-spring-boot-starter</artifactId>
+			<version>4.0.4</version>
+		</dependency>
+		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>

--- a/src/main/java/com/caseyquinn/personal_website/annotations/OperationsApiResponses.java
+++ b/src/main/java/com/caseyquinn/personal_website/annotations/OperationsApiResponses.java
@@ -1,0 +1,43 @@
+package com.caseyquinn.personal_website.annotations;
+
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Reusable Swagger response annotations for OperationsController endpoints.
+ * Each inner interface documents the expected HTTP status codes for one endpoint.
+ */
+public class OperationsApiResponses {
+
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Service is healthy")
+    })
+    public @interface Health {}
+
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Text encrypted successfully"),
+            @ApiResponse(responseCode = "400", description = "Invalid or blank input"),
+            @ApiResponse(responseCode = "403", description = "Not available in production"),
+            @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
+    public @interface Encrypt {}
+
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Text decrypted successfully"),
+            @ApiResponse(responseCode = "400", description = "Invalid or blank input"),
+            @ApiResponse(responseCode = "403", description = "Not available in production"),
+            @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
+    public @interface Decrypt {}
+}

--- a/src/main/java/com/caseyquinn/personal_website/annotations/ProjectApiResponses.java
+++ b/src/main/java/com/caseyquinn/personal_website/annotations/ProjectApiResponses.java
@@ -1,0 +1,78 @@
+package com.caseyquinn.personal_website.annotations;
+
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Reusable Swagger response annotations for ProjectController endpoints.
+ * Each inner interface documents the expected HTTP status codes for one endpoint.
+ */
+public class ProjectApiResponses {
+
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Projects retrieved successfully"),
+            @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
+    public @interface GetAll {}
+
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Paginated projects retrieved successfully"),
+            @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
+    public @interface GetPaginated {}
+
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Project retrieved successfully"),
+            @ApiResponse(responseCode = "404", description = "Project not found"),
+            @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
+    public @interface GetById {}
+
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Project created successfully"),
+            @ApiResponse(responseCode = "400", description = "Validation failed"),
+            @ApiResponse(responseCode = "409", description = "Duplicate project name"),
+            @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
+    public @interface Create {}
+
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Project updated successfully"),
+            @ApiResponse(responseCode = "400", description = "Validation failed"),
+            @ApiResponse(responseCode = "404", description = "Project not found"),
+            @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
+    public @interface Update {}
+
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Project deleted successfully"),
+            @ApiResponse(responseCode = "404", description = "Project not found"),
+            @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
+    public @interface Delete {}
+
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Projects filtered by technology"),
+            @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
+    public @interface GetByTechnology {}
+}

--- a/src/main/java/com/caseyquinn/personal_website/controller/OperationsController.java
+++ b/src/main/java/com/caseyquinn/personal_website/controller/OperationsController.java
@@ -1,0 +1,97 @@
+package com.caseyquinn.personal_website.controller;
+
+import com.caseyquinn.personal_website.annotations.OperationsApiResponses;
+import com.caseyquinn.personal_website.dto.request.EncryptionRequest;
+import com.caseyquinn.personal_website.dto.response.EncryptionResponse;
+import com.caseyquinn.personal_website.dto.response.HealthResponse;
+import com.caseyquinn.personal_website.dto.response.Response;
+import com.caseyquinn.personal_website.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jasypt.util.text.TextEncryptor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "Operations", description = "Service health and utility operations")
+public class OperationsController {
+
+    private final Environment environment;
+    private final TextEncryptor textEncryptor;
+
+    @Value("${spring.application.name}")
+    private String applicationName;
+
+    @Value("${app.version:1.0.0}")
+    private String version;
+
+    @OperationsApiResponses.Health
+    @Operation(summary = "Health check", description = "Get service health status")
+    @GetMapping("/health")
+    public ResponseEntity<Response<HealthResponse>> health() {
+        log.debug("Health check requested");
+
+        HealthResponse health = HealthResponse.builder()
+                .status("UP")
+                .service(applicationName)
+                .version(version)
+                .environment(String.join(", ", environment.getActiveProfiles()))
+                .timestamp(LocalDateTime.now())
+                .build();
+
+        return ResponseEntity.ok(Response.success(health, "Service is healthy"));
+    }
+
+    @OperationsApiResponses.Encrypt
+    @Operation(summary = "Encrypt text",
+            description = "Encrypt plaintext for use in property files. Returns an ENC(...) wrapped value. Not available in production.")
+    @PostMapping("/operations/encrypt")
+    public ResponseEntity<Response<EncryptionResponse>> encrypt(@Valid @RequestBody EncryptionRequest request) {
+        if (isProductionProfile()) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(Response.error(ErrorCode.FORBIDDEN.getCode(), "This endpoint is not available in production"));
+        }
+        log.info("Encrypting text");
+        String encrypted = textEncryptor.encrypt(request.getText());
+        return ResponseEntity.ok(Response.success(
+                EncryptionResponse.builder().text("ENC(" + encrypted + ")").build(),
+                "Text encrypted successfully"));
+    }
+
+    @OperationsApiResponses.Decrypt
+    @Operation(summary = "Decrypt text",
+            description = "Decrypt an ENC(...) wrapped ciphertext back to plaintext. Not available in production.")
+    @PostMapping("/operations/decrypt")
+    public ResponseEntity<Response<EncryptionResponse>> decrypt(@Valid @RequestBody EncryptionRequest request) {
+        if (isProductionProfile()) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(Response.error(ErrorCode.FORBIDDEN.getCode(), "This endpoint is not available in production"));
+        }
+        log.info("Decrypting text");
+        String input = request.getText();
+        if (input.startsWith("ENC(") && input.endsWith(")")) {
+            input = input.substring(4, input.length() - 1);
+        }
+        String decrypted = textEncryptor.decrypt(input);
+        return ResponseEntity.ok(Response.success(
+                EncryptionResponse.builder().text(decrypted).build(),
+                "Text decrypted successfully"));
+    }
+
+    private boolean isProductionProfile() {
+        return Arrays.stream(environment.getActiveProfiles())
+                .anyMatch(p -> p.equalsIgnoreCase("production"));
+    }
+}

--- a/src/main/java/com/caseyquinn/personal_website/controller/ProjectController.java
+++ b/src/main/java/com/caseyquinn/personal_website/controller/ProjectController.java
@@ -1,19 +1,17 @@
 package com.caseyquinn.personal_website.controller;
 
+import com.caseyquinn.personal_website.annotations.ProjectApiResponses;
 import com.caseyquinn.personal_website.dto.request.CreateProjectRequest;
 import com.caseyquinn.personal_website.dto.request.UpdateProjectRequest;
-import com.caseyquinn.personal_website.dto.response.Response;
-import com.caseyquinn.personal_website.dto.response.HealthResponse;
 import com.caseyquinn.personal_website.dto.response.ProjectResponse;
+import com.caseyquinn.personal_website.dto.response.Response;
 import com.caseyquinn.personal_website.service.ProjectService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -22,8 +20,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-import jakarta.validation.Valid;
-import java.time.LocalDateTime;
 import java.util.List;
 
 @RestController
@@ -35,35 +31,8 @@ import java.util.List;
 public class ProjectController {
     
     private final ProjectService projectService;
-    
-    @Value("${spring.application.name}")
-    private String applicationName;
-    
-    @Value("${app.version:1.0.0}")
-    private String version;
-    
-    @Value("${spring.profiles.active:unknown}")
-    private String environment;
-    
-    @Operation(summary = "Health check", description = "Get service health status")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Service is healthy")
-    })
-    @GetMapping("/health")
-    public ResponseEntity<Response<HealthResponse>> health() {
-        log.debug("Health check requested");
-        
-        HealthResponse health = HealthResponse.builder()
-                .status("UP")
-                .service(applicationName)
-                .version(version)
-                .environment(environment)
-                .timestamp(LocalDateTime.now())
-                .build();
-                
-        return ResponseEntity.ok(Response.success(health, "Service is healthy"));
-    }
-    
+
+    @ProjectApiResponses.GetAll
     @Operation(summary = "Get all projects", description = "Retrieve a list of all projects")
     @GetMapping("/projects")
     public ResponseEntity<Response<List<ProjectResponse>>> getAllProjects() {
@@ -72,6 +41,7 @@ public class ProjectController {
         return ResponseEntity.ok(Response.success(projects, "Projects retrieved successfully"));
     }
     
+    @ProjectApiResponses.GetPaginated
     @Operation(summary = "Get projects with pagination", description = "Retrieve projects with pagination support")
     @GetMapping("/projects/paginated")
     public ResponseEntity<Response<Page<ProjectResponse>>> getProjectsPaginated(
@@ -81,6 +51,7 @@ public class ProjectController {
         return ResponseEntity.ok(Response.success(projects, "Projects retrieved successfully"));
     }
     
+    @ProjectApiResponses.GetById
     @Operation(summary = "Get project by ID", description = "Retrieve a specific project by its ID")
     @GetMapping("/projects/{id}")
     public ResponseEntity<Response<ProjectResponse>> getProject(
@@ -90,6 +61,7 @@ public class ProjectController {
         return ResponseEntity.ok(Response.success(project, "Project retrieved successfully"));
     }
     
+    @ProjectApiResponses.Create
     @Operation(summary = "Create new project", description = "Create a new project")
     @PostMapping("/projects")
     public ResponseEntity<Response<ProjectResponse>> createProject(
@@ -100,6 +72,7 @@ public class ProjectController {
                 .body(Response.success(project, "Project created successfully"));
     }
     
+    @ProjectApiResponses.Update
     @Operation(summary = "Update project", description = "Update an existing project")
     @PutMapping("/projects/{id}")
     public ResponseEntity<Response<ProjectResponse>> updateProject(
@@ -110,6 +83,7 @@ public class ProjectController {
         return ResponseEntity.ok(Response.success(project, "Project updated successfully"));
     }
     
+    @ProjectApiResponses.Delete
     @Operation(summary = "Delete project", description = "Delete a project by ID")
     @DeleteMapping("/projects/{id}")
     public ResponseEntity<Response<Void>> deleteProject(
@@ -119,6 +93,7 @@ public class ProjectController {
         return ResponseEntity.ok(Response.success(null, "Project deleted successfully"));
     }
     
+    @ProjectApiResponses.GetByTechnology
     @Operation(summary = "Get projects by technology", description = "Retrieve projects that use a specific technology")
     @GetMapping("/projects/technology/{technology}")
     public ResponseEntity<Response<List<ProjectResponse>>> getProjectsByTechnology(

--- a/src/main/java/com/caseyquinn/personal_website/dto/request/EncryptionRequest.java
+++ b/src/main/java/com/caseyquinn/personal_website/dto/request/EncryptionRequest.java
@@ -1,0 +1,14 @@
+package com.caseyquinn.personal_website.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+@Schema(description = "Encryption or decryption request")
+public class EncryptionRequest {
+
+    @NotBlank(message = "Text must not be blank")
+    @Schema(description = "Text to encrypt or decrypt", example = "my-secret-value")
+    private String text;
+}

--- a/src/main/java/com/caseyquinn/personal_website/dto/response/EncryptionResponse.java
+++ b/src/main/java/com/caseyquinn/personal_website/dto/response/EncryptionResponse.java
@@ -1,0 +1,14 @@
+package com.caseyquinn.personal_website.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@Schema(description = "Encryption or decryption response")
+public class EncryptionResponse {
+
+    @Schema(description = "Resulting text after encryption or decryption")
+    private String text;
+}

--- a/src/main/java/com/caseyquinn/personal_website/dto/response/Response.java
+++ b/src/main/java/com/caseyquinn/personal_website/dto/response/Response.java
@@ -13,7 +13,10 @@ public class Response<T> {
     
     @Schema(description = "Response status", example = "success")
     private String status;
-    
+
+    @Schema(description = "Machine-readable error code, present on error responses", example = "NOT_FOUND")
+    private String errorCode;
+
     @Schema(description = "Response message", example = "Operation completed successfully")
     private String message;
     
@@ -47,6 +50,15 @@ public class Response<T> {
     public static <T> Response<T> error(String message) {
         return Response.<T>builder()
                 .status("error")
+                .message(message)
+                .timestamp(LocalDateTime.now())
+                .build();
+    }
+
+    public static <T> Response<T> error(String errorCode, String message) {
+        return Response.<T>builder()
+                .status("error")
+                .errorCode(errorCode)
                 .message(message)
                 .timestamp(LocalDateTime.now())
                 .build();

--- a/src/main/java/com/caseyquinn/personal_website/dto/response/ValidationErrorResponse.java
+++ b/src/main/java/com/caseyquinn/personal_website/dto/response/ValidationErrorResponse.java
@@ -1,0 +1,28 @@
+package com.caseyquinn.personal_website.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+@Schema(description = "Validation error details")
+public class ValidationErrorResponse {
+
+    @Schema(description = "List of field-level validation errors")
+    private List<FieldError> errors;
+
+    @Data
+    @Builder
+    @Schema(description = "Single field validation error")
+    public static class FieldError {
+
+        @Schema(description = "Field name that failed validation", example = "name")
+        private String field;
+
+        @Schema(description = "Validation error message", example = "must not be blank")
+        private String message;
+    }
+}

--- a/src/main/java/com/caseyquinn/personal_website/exception/ErrorCode.java
+++ b/src/main/java/com/caseyquinn/personal_website/exception/ErrorCode.java
@@ -19,9 +19,16 @@ public enum ErrorCode {
     // Data Access
     DB_CONNECTION_ERROR("DB_CONNECTION", "Database connection failed"),
     DB_INTEGRITY_ERROR("DB_INTEGRITY", "Data integrity violation"),
+    DB_ACCESS_ERROR("DB_ACCESS", "A data access error occurred"),
+
+    // Security
+    FORBIDDEN("FORBIDDEN", "Access denied"),
 
     // Rate Limiting
-    RATE_LIMIT_EXCEEDED("RATE_LIMIT", "Too many requests");
+    RATE_LIMIT_EXCEEDED("RATE_LIMIT", "Too many requests"),
+
+    // Generic
+    INTERNAL_ERROR("INTERNAL_ERROR", "An unexpected error occurred");
 
     private final String code;
     private final String defaultMessage;


### PR DESCRIPTION
Closes #6

## Summary
- Health check moved out of ProjectController into a new OperationsController
- Encrypt/decrypt endpoints added via `jasypt-spring-boot-starter` — returns `ENC(...)` values ready to drop into property files; blocked with 403 when production profile is active
- All ProjectController and OperationsController endpoints now have full Swagger response docs via reusable inner-interface annotation classes in the `annotations` package
- Every error response now includes a machine-readable `errorCode` field in the JSON body
- Validation errors return a typed `ValidationErrorResponse` DTO instead of a raw Map

## Test plan
- [ ] Verify `mvn clean compile` passes
- [ ] Hit `POST /api/v1/operations/encrypt` with a plaintext value, confirm `ENC(...)` output
- [ ] Paste the `ENC(...)` output into `POST /api/v1/operations/decrypt`, confirm original value returned
- [ ] Confirm encrypt/decrypt return 403 when `production` profile is active
- [ ] Trigger a validation error (e.g. POST project with blank name), confirm response includes `errorCode` and typed field errors
- [ ] Confirm `/api/v1/health` still works and returns correctly
- [ ] Check Swagger UI — all endpoints should show documented response codes

🤖 Generated with [Claude Code](https://claude.com/claude-code)