### PR TITLE
Add frontend service and edge routing for caseyrquinn.com

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -18,6 +18,13 @@ services:
     networks:
       - app-network
 
+  frontend:
+    image: ghcr.io/caseythecoder90/personal-website-frontend:latest
+    container_name: personal-website-frontend
+    restart: unless-stopped
+    networks:
+      - app-network
+
   postgres:
     image: postgres:16-alpine
     container_name: personal-website-postgres

--- a/docs/FRONTEND_INTEGRATION.md
+++ b/docs/FRONTEND_INTEGRATION.md
@@ -1,0 +1,216 @@
+# Frontend Integration Guide
+
+This document is the single entry point for frontend Claude Code agents integrating with the personal-website backend. Read this end-to-end; it links out to deeper references.
+
+> **Path on disk:** `C:\Users\casey\Projects\personal-website-backend\docs\FRONTEND_INTEGRATION.md`
+
+---
+
+## 1. Base URLs & Environments
+
+| Environment | Base URL | Notes |
+|---|---|---|
+| Local dev | `http://localhost:8080` | Spring Boot default port |
+| Production | `https://api.caseyrquinn.com` | Behind nginx + certbot SSL on VPS |
+
+All API routes are prefixed with `/api/v1`.
+
+- Swagger UI: `http://localhost:8080/swagger-ui.html`
+- OpenAPI JSON: `http://localhost:8080/v3/api-docs`
+- Health: `http://localhost:8080/actuator/health`
+
+## 2. CORS — Allowed Origins
+
+Configured in `SecurityConfig.corsConfigurationSource()`:
+
+- `http://localhost:*` (any port — Vite 5173, preview 4173, Lighthouse, etc.)
+- `http://127.0.0.1:*`
+- `https://caseyrquinn.com`
+- `https://www.caseyrquinn.com`
+
+Methods: `GET, POST, PUT, DELETE, OPTIONS`. Credentials allowed. Headers: `*`. Max age 3600s.
+
+If your dev origin isn't covered, edit `SecurityConfig.java` and restart the backend.
+
+## 3. Standard Response Envelope
+
+Every endpoint returns a `Response<T>`:
+
+**Success**
+```json
+{
+  "status": "success",
+  "message": "Operation completed successfully",
+  "data": { /* T */ },
+  "timestamp": "2026-04-30T12:34:56.789"
+}
+```
+
+**Error**
+```json
+{
+  "status": "error",
+  "errorCode": "NOT_FOUND",
+  "message": "Project with id 42 not found",
+  "timestamp": "2026-04-30T12:34:56.789"
+}
+```
+
+Common `errorCode` values: `VALIDATION_FAILED`, `NOT_FOUND`, `DUPLICATE_RESOURCE`, `FORBIDDEN`, `UNAUTHORIZED`, `MAX_IMAGES_EXCEEDED`, `INTERNAL_ERROR`. HTTP status mirrors the category (400 / 401 / 403 / 404 / 409 / 500).
+
+## 4. Authentication (JWT)
+
+- All `GET` endpoints are **public** (portfolio is publicly viewable).
+- All `POST` / `PUT` / `DELETE` endpoints require an **ADMIN** JWT, except:
+  - `POST /api/v1/contact` — public submission
+  - `PUT /api/v1/projects/{id}/views` — public view-count increment
+
+**Login**
+```
+POST /api/v1/auth/login
+Content-Type: application/json
+
+{ "username": "admin", "password": "..." }
+```
+Returns `{ data: { token, expiresIn, ... } }`. Use as:
+```
+Authorization: Bearer <token>
+```
+Token TTL: 24h. Refresh TTL: 7 days. See `docs/authentication/JWT_AUTHENTICATION_GUIDE.md`.
+
+For the public-facing frontend you typically only need unauthenticated GETs and the contact POST. Admin write operations are for the CMS-style admin UI.
+
+## 5. Endpoint Catalog
+
+The full route table (paths, methods, auth requirement) lives in the project README under `CLAUDE.md` → "API Endpoints", reproduced here at:
+
+- `C:\Users\casey\Projects\personal-website-backend\CLAUDE.md` (search "API Endpoints")
+
+High-level resource map:
+
+| Resource | Public reads | Admin writes |
+|---|---|---|
+| `/auth/login` | POST (public) | — |
+| `/projects` | list, paginated, by id, by slug, by technology, featured | POST/PUT/DELETE |
+| `/projects/{id}/views` | PUT (public increment) | — |
+| `/projects/{id}/links` | list, by id | POST/PUT/DELETE |
+| `/projects/{id}/images` | list, by id | POST (multipart), PUT, DELETE, set-primary |
+| `/technologies` | list, paginated, by id, name, category, proficiency, featured, most-used | POST/PUT/DELETE |
+| `/certifications` | list, by id, slug, status, organization, published, featured | POST/PUT/DELETE + link/unlink technology |
+| `/blog/posts` | list, published, by id, slug, category, tag, search | POST/PUT/DELETE + publish/unpublish + link categories/tags |
+| `/blog/categories` | list, by id, slug | POST/PUT/DELETE |
+| `/blog/tags` | list, popular, by id, slug | POST/PUT/DELETE |
+| `/blog/posts/{id}/images` | list, by id | POST (multipart), PUT, DELETE, primary |
+| `/contact` | POST (public submit) | GET list, by id, by status, by inquiry-type, PUT status, DELETE |
+| `/resume` | GET metadata, GET `/download` (302 → Cloudinary) | POST (multipart PDF), DELETE |
+| `/operations` | health | encrypt, decrypt, hash-password |
+
+**Definitive sources** for request/response shapes:
+- Live OpenAPI: `http://localhost:8080/v3/api-docs` (most authoritative — generated from code)
+- Swagger UI: `http://localhost:8080/swagger-ui.html`
+- DTOs in `src/main/java/com/caseyquinn/personal_website/dto/`
+- Postman collection: `docs/api/postman/personal-website-api.postman_collection.json`
+- Sample requests: `docs/api/sample-requests/{projects,technologies,images,operations}/`
+
+## 6. Pagination, Sorting, Filtering
+
+Paginated endpoints (`/paginated`) accept Spring's standard query params:
+- `page` (0-indexed), `size` (default 10), `sort` (e.g. `createdAt,desc`)
+
+Response is a Spring `Page<T>` shape inside `data`: `{ content: [...], totalElements, totalPages, number, size, ... }`.
+
+Default sort for projects: `createdAt DESC` (newest first).
+
+## 7. File Uploads
+
+**Project images / blog post images**
+```
+POST /api/v1/projects/{id}/images
+POST /api/v1/blog/posts/{postId}/images
+Content-Type: multipart/form-data
+Authorization: Bearer <admin token>
+
+Form fields:
+  file:        (image file)
+  imageType:   THUMBNAIL | GALLERY | HERO | ...
+  altText:     string
+  caption:     string (optional)
+  displayOrder: number (optional)
+  isPrimary:   boolean (optional)
+```
+
+**Resume**
+```
+POST /api/v1/resume
+Content-Type: multipart/form-data
+Authorization: Bearer <admin token>
+
+Form fields:
+  file:        (PDF, max 5MB)
+```
+Resume download is a 302 redirect to Cloudinary — use `<a href="/api/v1/resume/download" download>` or `window.location.href = ...`. Don't `fetch().json()` it.
+
+Limits: max 10 projects, max 20 images per blog post, single active resume.
+
+## 8. Business Rules the Frontend Should Mirror
+
+- Project / certification / blog post **slugs auto-generate** from name on creation — don't try to set them directly unless updating.
+- Published projects/certifications **cannot be deleted** — unpublish first.
+- Blog posts start **unpublished**; publish/unpublish are explicit endpoints.
+- Contact submission statuses: `NEW → READ → REPLIED → ARCHIVED`.
+- Contact form is public; the backend sends a confirmation email to the submitter and a notification email to the owner asynchronously via Resend.
+
+## 9. Enums (use these literal string values)
+
+- `ProjectType`, `ProjectStatus`, `DifficultyLevel`
+- `TechnologyCategory`, `ProficiencyLevel`
+- `ImageType`, `BlogImageType`
+- `LinkType` (GITHUB, LIVE, DEMO, DOCS, ...)
+- `CertificationStatus` (EARNED, IN_PROGRESS, EXPIRED)
+- `InquiryType`, `SubmissionStatus`
+- `UserRole`
+
+For exact members, query OpenAPI or read the enum source under `src/main/java/com/caseyquinn/personal_website/entity/enums/`.
+
+## 10. Deployment Notes for the Frontend
+
+When deploying to production, the frontend should:
+- Use `VITE_API_BASE_URL=https://api.caseyrquinn.com/api/v1` (or wherever the deployed backend lives).
+- Use `withCredentials: true` only if you need cookies — JWT via `Authorization` header does not require it. (CORS allows credentials either way.)
+- Treat `/api/v1/resume/download` as a redirect, not JSON.
+- Never log the JWT; store it in memory or sessionStorage for admin flows.
+
+Backend deployment reference docs (read only if you're touching infra):
+- `docs/deployment/VPS_DEPLOYMENT.md`
+- `docs/deployment/NGINX_REVERSE_PROXY.md`
+- `docs/deployment/CERTBOT_SSL.md`
+- `docs/deployment/DOCKER.md`
+- `docs/deployment/GITHUB_ACTIONS_CICD.md`
+
+## 11. Quick Smoke Test from the Frontend
+
+```bash
+# health
+curl http://localhost:8080/actuator/health
+
+# list published projects
+curl http://localhost:8080/api/v1/projects
+
+# get current resume metadata
+curl http://localhost:8080/api/v1/resume
+```
+
+If CORS fails: hard-refresh (Ctrl+Shift+R), check the Network tab for `Access-Control-Allow-Origin`, and confirm your origin matches a pattern in section 2.
+
+## 12. Where to Look Next
+
+| If you need… | Read |
+|---|---|
+| Exact request/response schemas | OpenAPI at `/v3/api-docs` (live) or Swagger UI |
+| Auth flow details | `docs/authentication/JWT_AUTHENTICATION_GUIDE.md` |
+| Sequence diagrams | `docs/api/API_FLOWS.md`, `docs/architecture/DIAGRAMS.md` |
+| System design context | `docs/architecture/SYSTEM_DESIGN.md` |
+| Database schema | `docs/architecture/database-schema.dbml` |
+| Sample requests | `docs/api/sample-requests/` |
+| Postman collection | `docs/api/postman/personal-website-api.postman_collection.json` |
+| Full endpoint table | `CLAUDE.md` (project root) |

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -41,3 +41,69 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 }
+
+# ---------------------------------------------------------------------------
+# Frontend — caseyrquinn.com and www.caseyrquinn.com
+# ---------------------------------------------------------------------------
+
+# HTTP: serve ACME challenges for cert renewal, redirect everything else to
+# HTTPS. Same pattern as the api block above.
+server {
+    listen 80;
+    server_name caseyrquinn.com www.caseyrquinn.com;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+# HTTPS: www → apex 301 redirect. Pick a canonical hostname (apex) so SEO
+# doesn't see two parallel sites and so HSTS is consistent. Uses the same
+# cert as the apex (issued via certbot with -d caseyrquinn.com -d www.caseyrquinn.com).
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name www.caseyrquinn.com;
+
+    ssl_certificate /etc/letsencrypt/live/caseyrquinn.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/caseyrquinn.com/privkey.pem;
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+    ssl_prefer_server_ciphers on;
+
+    return 301 https://caseyrquinn.com$request_uri;
+}
+
+# HTTPS: serve the frontend SPA. Reverse-proxies to the frontend container,
+# which is itself an internal nginx serving the built Vite bundle with SPA
+# fallback. Same SSL hardening + security headers as the api block.
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name caseyrquinn.com;
+
+    ssl_certificate /etc/letsencrypt/live/caseyrquinn.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/caseyrquinn.com/privkey.pem;
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+    ssl_prefer_server_ciphers on;
+
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
+    location / {
+        proxy_pass http://frontend:80;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/src/main/java/com/caseyquinn/personal_website/config/SecurityConfig.java
+++ b/src/main/java/com/caseyquinn/personal_website/config/SecurityConfig.java
@@ -104,9 +104,9 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of(
-                "http://localhost:3000",
-                "http://localhost:4200",
+        configuration.setAllowedOriginPatterns(List.of(
+                "http://localhost:*",
+                "http://127.0.0.1:*",
                 "https://caseyrquinn.com",
                 "https://www.caseyrquinn.com"
         ));


### PR DESCRIPTION
## Summary

- Adds `frontend` service to `docker-compose.prod.yml` (internal-only, pulls `ghcr.io/caseythecoder90/personal-website-frontend:latest`)
- Adds three nginx server blocks: HTTP→HTTPS for apex+www, www→apex 301, and HTTPS frontend reverse proxy with SSL hardening + security headers matching the existing api block
- Widens dev CORS via `setAllowedOriginPatterns` to allow any `localhost:*` / `127.0.0.1:*` port (Vite 5173, preview 4173, Lighthouse, etc.)
- Adds `docs/FRONTEND_INTEGRATION.md` as a single-entry doc for frontend Claude Code agents (base URLs, CORS, response envelope, JWT auth, endpoint catalog, file uploads, business rules, deployment notes)

## Why this is auto-deploy-safe

The deploy workflow only runs `pull app` + `up -d app`, so:
- The new `frontend` service sits dormant until `docker compose up -d frontend` is run.
- The new nginx server blocks are NOT loaded until `nginx -s reload` is run.
- Until then the api keeps serving traffic unchanged.

## Operator steps after merge

```bash
cd /opt/personal-website

# 1. Issue cert (HTTP-01 challenge — port 80 still works from existing api block)
docker compose -f docker-compose.prod.yml run --rm certbot \
  certonly --webroot --webroot-path=/var/www/certbot \
  --email <operator-email> --agree-tos --no-eff-email \
  -d caseyrquinn.com -d www.caseyrquinn.com

# 2. Verify cert exists
ls -la /opt/personal-website/certbot/conf/live/caseyrquinn.com/

# 3. Reload nginx (picks up new server blocks + cert)
docker compose -f docker-compose.prod.yml exec nginx nginx -s reload

# 4. Optional — bring up frontend if image already in GHCR
docker compose -f docker-compose.prod.yml up -d frontend
```

Step 4 is optional: the frontend repo's own deploy workflow runs `docker compose pull frontend && up -d frontend` over SSH on the next push to its main.

## Test plan

- [ ] CI build passes
- [ ] Auto-deploy completes and api remains reachable at https://api.caseyrquinn.com
- [ ] Operator issues cert via certbot
- [ ] `nginx -t` inside the nginx container passes after cert exists
- [ ] `nginx -s reload` succeeds
- [ ] `curl -I https://caseyrquinn.com` returns 200 (after frontend service is up)
- [ ] `curl -I https://www.caseyrquinn.com` returns 301 to https://caseyrquinn.com
- [ ] Frontend can call https://api.caseyrquinn.com/api/v1/projects with no CORS errors
- [ ] Local Lighthouse from a Vite preview port (4173) succeeds against http://localhost:8080

🤖 Generated with [Claude Code](https://claude.com/claude-code)